### PR TITLE
Hard coded trinket procs for spell crit and hit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1383,19 +1383,6 @@ def process_trinkets(
         if active_stats['stat_name'] == 'Strength':
             active_stats['stat_name'] = 'attack_power'
             active_stats['stat_increment'] *= 2 * stat_mod * ap_mod
-        if active_stats['stat_name'] == 'crit_chance':
-            active_stats['stat_name'] = ['crit_chance', 'spell_crit_chance']
-            cirt_increment = active_stats['stat_increment']
-            active_stats['stat_increment'] = np.array([
-                cirt_increment, cirt_increment
-            ])
-        if active_stats['stat_name'] == 'hit_chance':
-            active_stats['stat_name'] = ['hit_chance', 'spell_hit_chance']
-            hit_increment = active_stats['stat_increment']
-            active_stats['stat_increment'] = np.array([
-                hit_increment, hit_increment
-            ])
-
 
         if trinket_params['type'] == 'activated':
             # If this is the second trinket slot and the first trinket was also

--- a/main.py
+++ b/main.py
@@ -1383,6 +1383,19 @@ def process_trinkets(
         if active_stats['stat_name'] == 'Strength':
             active_stats['stat_name'] = 'attack_power'
             active_stats['stat_increment'] *= 2 * stat_mod * ap_mod
+        if active_stats['stat_name'] == 'crit_chance':
+            active_stats['stat_name'] = ['crit_chance', 'spell_crit_chance']
+            cirt_increment = active_stats['stat_increment']
+            active_stats['stat_increment'] = np.array([
+                cirt_increment, cirt_increment
+            ])
+        if active_stats['stat_name'] == 'hit_chance':
+            active_stats['stat_name'] = ['hit_chance', 'spell_hit_chance']
+            hit_increment = active_stats['stat_increment']
+            active_stats['stat_increment'] = np.array([
+                hit_increment, hit_increment
+            ])
+
 
         if trinket_params['type'] == 'activated':
             # If this is the second trinket slot and the first trinket was also

--- a/player.py
+++ b/player.py
@@ -21,6 +21,15 @@ class Player():
         self.calc_miss_chance()
 
     @property
+    def spell_hit_chance(self):
+        return self._spell_hit_chance
+    
+    @spell_hit_chance.setter
+    def spell_hit_chance(self, value):
+        self._spell_hit_chance = value
+        self.calc_spell_miss_chance()
+
+    @property
     def expertise_rating(self):
         return self._expertise_rating
 
@@ -210,7 +219,11 @@ class Player():
             (8. - miss_reduction) + (6.5 - dodge_reduction)
         )
         self.dodge_chance = 0.01 * (6.5 - dodge_reduction)
-        spell_miss_reduction = min(self.spell_hit_chance * 100, 17.0)
+
+    def calc_spell_miss_chance(self):
+        """Update spell miss chance when a change to the player's spell
+        hit percent occurs."""
+        spell_miss_reduction = min(self._spell_hit_chance * 100, 17.0)
         self.spell_miss_chance = 0.01 * (17.0 - spell_miss_reduction)
 
     def calc_crit_multiplier(self):

--- a/trinkets.py
+++ b/trinkets.py
@@ -835,6 +835,7 @@ trinket_library = {
         'type': 'activated',
         'passive_stats': {
             'hit_chance': 55./32.79/100,
+            'spell_hit_chance': 55./26.23/100,
         },
         'active_stats': {
             'stat_name': 'attack_power',
@@ -887,6 +888,7 @@ trinket_library = {
         'type': 'activated',
         'passive_stats': {
             'crit_chance': 84./45.91/100,
+            'spell_crit_chance': 84./45.91/100,
         },
         'active_stats': {
             'stat_name': 'attack_power',
@@ -900,6 +902,7 @@ trinket_library = {
         'type': 'proc',
         'passive_stats': {
             'crit_chance': 74./45.91/100,
+            'spell_crit_chance': 74./45.91/100,
         },
         'active_stats': {
             'stat_name': 'haste_rating',
@@ -915,6 +918,7 @@ trinket_library = {
         'type': 'proc',
         'passive_stats': {
             'crit_chance': 84./45.91/100,
+            'spell_crit_chance': 84./45.91/100,
         },
         'active_stats': {
             'stat_name': 'attack_power',
@@ -975,6 +979,7 @@ trinket_library = {
         'type': 'instant_damage',
         'passive_stats': {
             'crit_chance': 85./45.91/100,
+            'spell_crit_chance': 85./45.91/100,
         },
         'active_stats': {
             'stat_name': 'none',
@@ -990,6 +995,7 @@ trinket_library = {
         'type': 'instant_damage',
         'passive_stats': {
             'crit_chance': 84./45.91/100,
+            'spell_crit_chance': 84./45.91/100,
         },
         'active_stats': {
             'stat_name': 'none',
@@ -1020,6 +1026,7 @@ trinket_library = {
         'type': 'instant_damage',
         'passive_stats': {
             'crit_chance': 95./45.91/100,
+            'spell_crit_chance': 95./45.91/100,
         },
         'active_stats': {
             'stat_name': 'none',
@@ -1066,6 +1073,7 @@ trinket_library = {
         'type': 'proc',
         'passive_stats': {
             'hit_chance': 83./32.79/100,
+            'spell_hit_chance': 83./26.23/100,
         },
         'active_stats': {
             'stat_name': 'armor_pen_rating',
@@ -1096,6 +1104,7 @@ trinket_library = {
         'type': 'refreshing_proc',
         'passive_stats': {
             'hit_chance': 20./32.79/100,
+            'spell_hit_chance': 20./26.23/100,
             'attack_power': 84,
         },
         'active_stats': {
@@ -1113,6 +1122,7 @@ trinket_library = {
         'passive_stats': {
             'attack_power': 100,
             'crit_chance': 50./45.91/100,
+            'spell_crit_chance': 50./45.91/100,
         },
     },
     'bns': {
@@ -1185,6 +1195,7 @@ trinket_library = {
         'type': 'proc',
         'passive_stats': {
             'crit_chance': 115./45.91/100,
+            'spell_crit_chance': 115./45.91/100,
         },
         'active_stats': {
             'stat_name': 'armor_pen_rating',
@@ -1200,6 +1211,7 @@ trinket_library = {
         'type': 'proc',
         'passive_stats': {
             'hit_chance': 100./32.79/100,
+            'spell_hit_chance': 100./26.23/100,
         },
         'active_stats': {
             'stat_name': 'attack_power',
@@ -1215,6 +1227,7 @@ trinket_library = {
         'type': 'proc',
         'passive_stats': {
             'hit_chance': 114./32.79/100,
+            'spell_hit_chance': 114./26.23/100,
         },
         'active_stats': {
             'stat_name': 'attack_power',
@@ -1230,6 +1243,7 @@ trinket_library = {
         'type': 'activated',
         'passive_stats': {
             'crit_chance': 114./45.91/100,
+            'spell_crit_chance': 114./45.91/100,
         },
         'active_stats': {
             'stat_name': 'attack_power',

--- a/trinkets.py
+++ b/trinkets.py
@@ -1182,8 +1182,8 @@ trinket_library = {
             'attack_power': 251,
         },
         'active_stats': {
-            'stat_name': 'crit_chance',
-            'stat_increment': 692./45.91/100,
+            'stat_name': ['crit_chance', 'spell_crit_chance'],
+            'stat_increment': np.array([692./45.91/100, 692./45.91/100]),
             'proc_name': 'Dark Matter',
             'proc_duration': 10,
             'cooldown': 45,

--- a/wotlk_cat_sim.py
+++ b/wotlk_cat_sim.py
@@ -2206,6 +2206,14 @@ class Simulation():
         if param == 'agility':
             self.player.attack_power += self.player.ap_mod * increment
             self.player.crit_chance += increment / 83.33 / 100.
+        
+        # For Hit chance increments, also augment Spell Hit chance
+        if param == 'hit_chance':
+            self.player.spell_hit_chance += increment * 32.79 / 26.23
+
+        # For Crit chance increments, also augment Spell Crit chance
+        if param == 'crit_chance':
+            self.player.spell_crit_chance += increment
 
         # Calculate DPS
         dps_vals = self.run_replicates(num_replicates)
@@ -2220,6 +2228,12 @@ class Simulation():
         if param == 'agility':
             self.player.attack_power -= self.player.ap_mod * increment
             self.player.crit_chance -= increment / 83.33 / 100.
+
+        if param == 'hit_chance':
+            self.player.spell_hit_chance -= increment * 32.79 / 26.23
+
+        if param == 'crit_chance':
+            self.player.spell_crit_chance -= increment
 
         return avg_dps - base_dps
 
@@ -2267,6 +2281,8 @@ class Simulation():
 
         # For hit, we reduce miss chance by 2% if well below hit cap, and
         # increase miss chance by 2% when already capped or close.
+        # Assumption made here is that the player should only be concerned
+        # with the melee hit
         sign = 1 - 2 * int(
             self.player.miss_chance - self.player.dodge_chance > 0.02
         )


### PR DESCRIPTION
Hard coded trinket spell hit and spell crit into trinket library.
Also modified calc_deriv function so that a percentage change to hit and crit will also change spell hit and spell crit.
The sign of the deriative for hit is still using the melee hit cap.
Add setter for spell hit