### PR TITLE
Allow putting trinket on ICD before combat

### DIFF
--- a/trinkets.py
+++ b/trinkets.py
@@ -407,7 +407,8 @@ class ProcTrinket(Trinket):
     def __init__(
         self, stat_name, stat_increment, proc_name, chance_on_hit,
         proc_duration, cooldown, chance_on_crit=0.0, yellow_chance_on_hit=None,
-        mangle_only=False, cat_mangle_only=False, shred_only=False, periodic_only=False
+        mangle_only=False, cat_mangle_only=False, shred_only=False, periodic_only=False,
+        icd_precombat=0.0
     ):
         """Initialize a generic proc trinket with key parameters.
 
@@ -441,7 +442,11 @@ class ProcTrinket(Trinket):
                 able to proc exclusively on the Shred ability. Defaults False.
             periodic_only (bool): If True, then designate this trinket as being
                 able to proc exclusively on periodic damage. Defaults False.
+            icd_precombat (float): Optional time (in seconds) of resetting the
+                trinket's internal cooldown before the fight. For example, 
+                equipping trinkets before pull. Defaults to 0.0.
         """
+        self.icd_precombat = icd_precombat
         Trinket.__init__(
             self, stat_name, stat_increment, proc_name, proc_duration,
             cooldown
@@ -504,7 +509,12 @@ class ProcTrinket(Trinket):
 
     def reset(self):
         """Set trinket to fresh inactive state with no cooldown remaining."""
-        Trinket.reset(self)
+        self.can_proc = self.icd_precombat > self.cooldown - 1e-9 if self.icd_precombat else True
+        self.activation_time = -self.icd_precombat if self.icd_precombat else -np.inf
+        self.active = False
+        self.num_procs = 0
+        self.uptime = 0.0
+        self.last_update = 0.0
         self.proc_happened = False
 
 
@@ -562,7 +572,7 @@ class StackingProcTrinket(ProcTrinket):
     def __init__(
         self, stat_name, stat_increment, max_stacks, aura_name, stack_name,
         chance_on_hit, yellow_chance_on_hit, aura_duration, cooldown,
-        aura_type='activated', aura_proc_rates=None
+        aura_type='activated', aura_proc_rates=None, icd_precombat = 0.0
     ):
         """Initialize a generic stacking proc trinket with key parameters.
 
@@ -610,7 +620,8 @@ class StackingProcTrinket(ProcTrinket):
             self, stat_name=stat_name, stat_increment=0, proc_name=aura_name,
             proc_duration=aura_duration, cooldown=cooldown,
             chance_on_hit=self.stack_proc_rates['white'],
-            yellow_chance_on_hit=self.stack_proc_rates['yellow']
+            yellow_chance_on_hit=self.stack_proc_rates['yellow'],
+            icd_precombat=icd_precombat
         )
 
     def reset(self):
@@ -707,7 +718,7 @@ class InstantDamageProc(ProcTrinket):
 
     def __init__(
         self, proc_name, min_damage, damage_range, cooldown, chance_on_hit,
-        chance_on_crit, **kwargs
+        chance_on_crit, icd_precombat=0.0, **kwargs
     ):
         """Initialize Trinket object.
 
@@ -728,7 +739,8 @@ class InstantDamageProc(ProcTrinket):
             self, stat_name='attack_power', stat_increment=0,
             proc_name=proc_name, proc_duration=0, cooldown=cooldown,
             chance_on_hit=chance_on_hit, chance_on_crit=chance_on_crit,
-            periodic_only=kwargs.get('periodic_only', False)
+            periodic_only=kwargs.get('periodic_only', False), 
+            icd_precombat=icd_precombat
         )
         self.min_damage = min_damage
         self.damage_range = damage_range


### PR DESCRIPTION
This PR adds an option below trinkets which allows you to simulate putting the trinkets on CD by equipping them before a pull. This change does not apply to on-use trinkets.
Currently, for simplicity, it only allows setting 1 value which will put all proc trinkets on cooldown that many seconds before combat begins.

If deemed necessary, we can add an additional field so each trinket can be put on it's on CD. We could also hide this dialog if the trinket was an "on-use" trinket, or if it has no internal cooldown.