### PR TITLE
Mangle during AE when mutilation idol is equipped

### DIFF
--- a/main.py
+++ b/main.py
@@ -2121,8 +2121,11 @@ def compute(
         )
         trinket_list.append(idol)
         player.proc_trinkets.append(idol)
+
+    mutilation_idol = None
+
     if 'idol_of_mutilation' in bonuses:
-        idol = trinkets.RefreshingProcTrinket(
+        mutilation_idol = trinkets.RefreshingProcTrinket(
             chance_on_hit=0.70,
             stat_name=['agility', 'attack_power', 'crit_chance'],
             stat_increment=np.array([
@@ -2134,8 +2137,8 @@ def compute(
             cat_mangle_only=True,
             shred_only=True
         )
-        trinket_list.append(idol)
-        player.proc_trinkets.append(idol)
+        trinket_list.append(mutilation_idol)
+        player.proc_trinkets.append(mutilation_idol)
     if 'mongoose' in bonuses:
         mongoose_ppm = 0.73
         mongoose_enchant = trinkets.RefreshingProcTrinket(
@@ -2228,7 +2231,7 @@ def compute(
         roar_clip_leeway=roar_clip_leeway, num_targets=target_count,
         trinkets=trinket_list, haste_multiplier=haste_multiplier,
         hot_uptime=hot_uptime / 100., mangle_idol=mangle_idol,
-        rake_idol=rake_idol
+        rake_idol=rake_idol, mutilation_idol=mutilation_idol
     )
     sim.set_active_debuffs(boss_debuffs)
     player.calc_damage_params(**sim.params)

--- a/wotlk_cat_sim.py
+++ b/wotlk_cat_sim.py
@@ -192,7 +192,7 @@ class Simulation():
 
     def __init__(
         self, player, fight_length, latency, trinkets=[], haste_multiplier=1.0,
-        hot_uptime=0.0, mangle_idol=None, rake_idol=None, **kwargs
+        hot_uptime=0.0, mangle_idol=None, rake_idol=None, mutilation_idol=None, **kwargs
     ):
         """Initialize simulation.
 
@@ -216,6 +216,8 @@ class Simulation():
                 automatically if appropriate.
             rake_idol (trinkets.ProcTrinket): Optional Rake/Lacerate proc Idol
                 to use.
+            mutilation_idol (trinkets.RefreshingProcTrinket): Optional Mangle/
+                Shred proc idol to use.
             kwargs (dict): Key, value pairs for all other encounter parameters,
                 including boss armor, relevant debuffs, and player stregy
                 specification. An error will be thrown if the parameter is not
@@ -228,6 +230,7 @@ class Simulation():
         self.trinkets = trinkets
         self.mangle_idol = mangle_idol
         self.rake_idol = rake_idol
+        self.mutilation_idol = mutilation_idol
         self.params = copy.deepcopy(self.default_params)
         self.strategy = copy.deepcopy(self.default_strategy)
 
@@ -1146,7 +1149,7 @@ class Simulation():
             # and (not self.player.omen_proc)
         )
         aoe_mangle = (
-            self.strategy['aoe'] and self.mangle_idol and (cp == 0) and
+            self.strategy['aoe'] and (self.mangle_idol or self.mutilation_idol) and (cp == 0) and
             ((not self.player.savage_roar) or (self.roar_end - time <= 1.0))
         )
         mangle_now = mangle_now or aoe_mangle


### PR DESCRIPTION
This PR makes the sim prioritize mangle over rake when the mutilation idol from T9 is equipped, rather than only when the corruptor idol from T8 is equipped.